### PR TITLE
Remove imports não utilizados 

### DIFF
--- a/backend/src/main/java/com/es/cinema/tickets/application/service/SalaService.java
+++ b/backend/src/main/java/com/es/cinema/tickets/application/service/SalaService.java
@@ -1,13 +1,9 @@
 package com.es.cinema.tickets.application.service;
 
-import com.es.cinema.tickets.exception.notfound.FilmeNotFoundException;
 import com.es.cinema.tickets.exception.notfound.SalaNotFoundException;
-import com.es.cinema.tickets.persistence.entity.Filme;
 import com.es.cinema.tickets.persistence.entity.Sala;
-import com.es.cinema.tickets.persistence.entity.Sessao;
 import com.es.cinema.tickets.persistence.repository.SalaRepository;
 import com.es.cinema.tickets.web.dto.response.SalaResponse;
-import com.es.cinema.tickets.web.dto.response.SessaoResponse;
 import com.es.cinema.tickets.web.mapper.SalaMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/es/cinema/tickets/web/mapper/SalaMapper.java
+++ b/backend/src/main/java/com/es/cinema/tickets/web/mapper/SalaMapper.java
@@ -1,8 +1,6 @@
 package com.es.cinema.tickets.web.mapper;
 
 import com.es.cinema.tickets.persistence.entity.Sala;
-import com.es.cinema.tickets.persistence.entity.Sessao;
-import com.es.cinema.tickets.web.dto.response.SalaResponse;
 import com.es.cinema.tickets.web.dto.response.SalaResponse;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
### Descrição
- Remove imports não utilizados no service e mapper de Sala, com intuito de resolver os erros de manutenibilidade acusados no SonarCloud.

Closes #79 